### PR TITLE
Add onCreateCommand for Zenn CLI installation in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
 	"image": "mcr.microsoft.com/devcontainers/base:debian",
 	"features": {
 		"ghcr.io/devcontainers-extra/features/deno:1": {}
-	}
+	},
+	"onCreateCommand": "deno install npm:zenn-cli"
 }


### PR DESCRIPTION
Include an `onCreateCommand` in the `devcontainer.json` to automate the installation of Zenn CLI during container creation.