### PR TITLE
Add Deno configuration files for Zenn CLI support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,6 @@
     "zenn-cli": "npm:zenn-cli@^0.2.3"
   },
   "tasks": {
-    "zenn": "deno run --allow-read=. --allow-write=. --allow-net --allow-env --allow-sys zenn-cli"
+    "zenn": "deno run --allow-read=.,$HOME,/proc/version --allow-write=.,$HOME/.config --allow-net=0.0.0.0,registry.npmjs.org:443,zenn.dev:443 --allow-env --allow-sys=homedir,osRelease zenn-cli"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,6 @@
     "zenn-cli": "npm:zenn-cli@^0.2.3"
   },
   "tasks": {
-    "zenn": "deno run --allow-read --allow-write --allow-net --allow-env --allow-sys zenn-cli"
+    "zenn": "deno run --allow-read=. --allow-write=. --allow-net --allow-env --allow-sys zenn-cli"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,8 @@
+{
+  "imports": {
+    "zenn-cli": "npm:zenn-cli@^0.2.3"
+  },
+  "tasks": {
+    "zenn": "deno run --allow-read --allow-write --allow-net --allow-env --allow-sys zenn-cli"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,17 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:zenn-cli@~0.2.3": "0.2.3"
+  },
+  "npm": {
+    "zenn-cli@0.2.3": {
+      "integrity": "sha512-ghYpg2foOeFExvtWKDFSjCsq+utYf84jApw37Wli1MnSAE1la40GZ47kXQDQKeh/1LV2AT0LDMYWbmE64Z4ZSg==",
+      "bin": true
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:zenn-cli@~0.2.3"
+    ]
+  }
+}


### PR DESCRIPTION
Introduce Deno configuration files to enable support for Zenn CLI, facilitating the execution of Zenn tasks within a Deno environment.