### PR TITLE
Fix remoteUser specification in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,6 @@
 	"features": {
 		"ghcr.io/devcontainers-extra/features/deno:1": {}
 	},
+	"remoteUser": "root",
 	"onCreateCommand": "deno install npm:zenn-cli"
 }


### PR DESCRIPTION
Ensure the `remoteUser` is correctly set to "root" in the devcontainer configuration.